### PR TITLE
Configuration fixes

### DIFF
--- a/config.py
+++ b/config.py
@@ -132,7 +132,6 @@ def parse_args(config):
         cli_key = key.replace('..', '.').lower()  # Ensure CLI arguments are lowercase
         parser.add_argument(f'--{cli_key}',
                             type=type(value),
-                            default=value,
                             help=f'Specify the {cli_key} value')
     args, unknown = parser.parse_known_args()
 

--- a/config.py
+++ b/config.py
@@ -4,8 +4,7 @@ import yaml
 import os
 import argparse
 import sys
-from typing import NamedTuple, Dict, Any
-from types import SimpleNamespace
+from typing import NamedTuple
 
 # Temporary logging configuration
 coloredlogs.install(level="WARN")
@@ -68,29 +67,6 @@ class Config(NamedTuple):
     docker: DockerConfig
     logLevel: LogLevelConfig
     traefik: TraefikConfig
-
-def dict_to_simplenamespace(dict_obj):
-    """
-    Recursively converts a nested dictionary into a SimpleNamespace object.
-
-    Args:
-        dict_obj (dict): The input dictionary to be converted.
-
-    Returns:
-        SimpleNamespace: The resulting SimpleNamespace object.
-    """
-    logging.info("Converting dictionary to SimpleNamespace")
-    logging.debug(f"Input dictionary: {dict_obj}")
-    if isinstance(dict_obj, dict):
-        for key, value in dict_obj.items():
-            logging.debug(f"Processing key: {key}")
-            dict_obj[key] = dict_to_simplenamespace(value)
-    elif isinstance(dict_obj, list):
-        logging.debug(f"Processing list with {len(dict_obj)} items")
-        return [dict_to_simplenamespace(item) for item in dict_obj]
-    result = SimpleNamespace(**dict_obj) if isinstance(dict_obj, dict) else dict_obj
-    logging.debug(f"Resulting SimpleNamespace or value: {result}")
-    return result
 
 def flatten_keys(d, parent_key='', sep='.'):
     """


### PR DESCRIPTION
This fixes 3 issues:

- I removed flags default values in order to prevent environment variable being overwritten by them.
- I merged the user defined configuration with the default one, so one can use a config file that doesn't define all configuration entries without crashing.
- I removed some dead code.

I figured out that using confuse as proposed in the issue would require to change a lot of code since confuse doesn't allow to parse configuration into custom objects. So I came up with something lighter that doesn't need to install any additional library.

Closes #7 