### PR TITLE
Performance improvements and host network issue fixes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,8 +28,8 @@ logLevel:
 traefik:
   # Name of the Traefik container
   containerName: "traefik"
-  # Label to monitor for Traefik management (using regex)
-  monitoredLabel: "^traefik.enable$"
+  # Label to monitor for Traefik management
+  monitoredLabel: "traefik.enable"
   # Label of traefik_network_connector network to connect to (not mandatory on services but if present, only connect to these networks)
   # For example, if you have 2 docker networks, "autoproxy.networks" label can be "autoproxy.networks=network1" to only connect to network1
   # DEPRECATED !

--- a/main.py
+++ b/main.py
@@ -150,7 +150,7 @@ def connect_traefik_to_network(container):
                     app_logger.debug(f"Adjusted allowed network to {real_network}.")
 
         # Connect Traefik to the network if allowed, or log that it's skipping the connection
-        if allowed_networks == [''] or net in allowed_networks:
+        if (allowed_networks == [''] or net in allowed_networks) and net.lower() != 'host':
             if net not in traefik_container.attrs["NetworkSettings"]["Networks"]:
                 app_logger.debug(f"Connecting Traefik to network {net}.")
                 network.connect(traefik_container)


### PR DESCRIPTION
Came across the PR #12 today and updated it with a few performance optimizations.
The script now doesn't loop through all Docker events anymore, as this uses pretty much one CPU core on larger systems. Filters for relevant events and the `monitoredLabel` exist, so that only events relevant for this tool are subscribed, including the `stop` event, @mbrodala introduced in his PR.
Also, this fixes #13 as from now on, connecting traefik to the network `host` is forbidden. (Could be made configurable, but I think connecting traefik to `network_mode: host` should be a manual action either way.)